### PR TITLE
Fix：修复mobile端主题选择页左右箭头无法切换问题

### DIFF
--- a/layout/theme.ejs
+++ b/layout/theme.ejs
@@ -13,8 +13,6 @@
         <% // 配置的主题个数小于等于10，采用10个图片的曲屏环形旋转样式布局 %>
         <% if (themeNum <= ROTATE_NUM) { %>
         <%- partial('_partial/rotate_theme', {themeImagePath: themeImagePath, themeNum: themeNum, rotateNum: ROTATE_NUM}) %>
-        <%- js('js/gsap-3.6.1.min') %>
-        <%- js('js/theme-rotate') %>
         <% } %>
     </div>
     <% // 配置的主题个数小于等于10，添加mobile端主题页左右切换箭头 %>
@@ -23,6 +21,8 @@
         <div class="left-arrow"></div>
         <div class="right-arrow"></div>
     </div>
+    <%- js('js/gsap-3.6.1.min') %>
+    <%- js('js/theme-rotate') %>
     <% } %>
 </div>
 


### PR DESCRIPTION
## PR Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

**Please read and check followings before submitting a PR.**

- [x] The changes have been tested (for bug fixes / features).
- [ ] Others (Update, Documentation, Translation, etc...)

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Improvement.
- [ ] Code style update (e.g. formatting).
- [ ] Refactoring (no changes to functionality and APIs).
- [ ] Documentation.
- [ ] Translation.
- [ ] Other... Please describe:

## 原因
theme-rotate.js 加载时，左右箭头html标签还没有加载，导致按钮事件无法绑定