### PR TITLE
Mod：开源页手机端展开箭头与卡片紧凑布局

### DIFF
--- a/layout/open.ejs
+++ b/layout/open.ejs
@@ -42,6 +42,9 @@
                                             <% if (p.source) { %><a class="open-link" href="<%= p.source %>" target="_blank" rel="noopener"><%= __('open.source') %></a><% } %>
                                             <% if (p.demo) { %><a class="open-link" href="<%= p.demo %>" target="_blank" rel="noopener"><%= __('open.demo') %></a><% } %>
                                             <% if (p.doc) { %><a class="open-link" href="<%= p.doc %>" target="_blank" rel="noopener"><%= __('open.doc') %></a><% } %>
+                                            <button class="open-toggle" type="button" aria-expanded="false" aria-label="<%= __('open.more') %>">
+                                                <svg class="open-toggle-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>
+                                            </button>
                                         </div>
                                     </div>
                                 </div>

--- a/source/css/_partial/open.styl
+++ b/source/css/_partial/open.styl
@@ -81,7 +81,7 @@
     background-color var(--content-bg-color)
     border 1px solid var(--header-divider-color)
     border-radius 8px
-    padding 20px
+    padding 16px
     box-shadow 0 3px 8px 6px rgba(7, 17, 27, 0.09)
     transition transform 0.2s, box-shadow 0.2s
     &:hover
@@ -191,7 +191,9 @@
 
 .open-links
     display flex
+    align-items center
     gap 12px
+    width 100%
 
 .open-link
     font-size 0.85em
@@ -205,6 +207,28 @@
     text-align center
     color color-gray
     padding 40px 0
+
+// 展开/收起箭头按钮（默认隐藏，仅手机端显示；置于 .open-links 行内最右）
+.open-toggle
+    display none
+    flex-shrink 0
+    align-items center
+    justify-content center
+    width 28px
+    height 28px
+    padding 0
+    border none
+    background transparent
+    color var(--text-color)
+    opacity 0.6
+    cursor pointer
+    -webkit-tap-highlight-color transparent
+    .open-toggle-ico
+        width 20px
+        height 20px
+        transition transform 0.2s ease
+    &:active
+        opacity 1
 
 // 方格布局（grid）：磁贴式，内容左对齐（logo 在顶部，文字靠左），同行卡片等高、链接贴底
 .open-grid
@@ -253,10 +277,11 @@
         min-width 0
         display flex
         flex-direction column
+        align-self stretch
         .open-name
             margin 0 0 8px 0
     .open-links
-        margin-top 0
+        margin-top auto
 
 @media mq-mobile
     // 方格：手机端保持两列磁贴；内容自适应，避免右侧溢出
@@ -264,12 +289,25 @@
         .inner
             // 手机端方格到屏幕左右边缘的间隔缩小（原 15px，现 8px；桌面 40px）
             padding 0 8px
+    // 手机端：卡片右下角展开/收起箭头；收起态隐藏 作者/语言/协议/标签
+    .open-toggle
+        display inline-flex
+        // 推到 .open-links 行最右，与 源码/文档/演示 同一行
+        margin-left auto
+    .open-card:not(.expanded)
+        .open-meta,
+        .open-tags
+            display none
+    .open-card.expanded
+        .open-toggle-ico
+            transform rotate(180deg)
     .open-grid
         grid-template-columns repeat(2, 1fr)
         // 手机端两列之间的间隔缩小（原为 12px）
         gap 8px
         .open-card
-            padding 12px
+            // 底部比其余三边小 2px（8px），让链接/箭头更贴底
+            padding 8px 8px 6px
             // grid item 默认 min-width:auto 会被内部内容撑开列宽，造成整体溢出右侧；归零后由内部断行控制
             min-width 0
             overflow-wrap anywhere
@@ -305,14 +343,15 @@
         .open-link
             font-size 0.78em
         .open-links
-            gap 8px
-            flex-wrap wrap
+            gap 6px
+            // 不换行，保证 箭头 与 源码/文档/演示 同行（列宽足够容纳短链接）
+            flex-wrap nowrap
     // 列表：单列横向行（图标+名称在左，描述/元信息/标签/链接在右）
     .open-list
         .open-card
             flex-direction row
             align-items flex-start
-            padding 12px
+            padding 8px 8px 6px
             gap 12px
         .open-card-head
             flex 0 0 auto
@@ -323,3 +362,8 @@
             margin 0
         .open-name
             font-size 1.05em
+        .open-links
+            gap 6px
+            flex-wrap nowrap
+            align-items center
+            width 100%

--- a/source/js/open.js
+++ b/source/js/open.js
@@ -18,6 +18,25 @@
         });
     });
 
+    // 手机端卡片展开/收起：同步所有卡片，避免同行等高拉伸留白
+    var toggles = document.querySelectorAll('.open-toggle');
+    var cards = document.querySelectorAll('.open-card');
+    function setAllExpanded(on) {
+        cards.forEach(function (c) { c.classList.toggle('expanded', on); });
+        toggles.forEach(function (t) {
+            t.setAttribute('aria-expanded', on ? 'true' : 'false');
+            t.setAttribute('aria-label', on ? collapseText : moreText);
+        });
+    }
+    toggles.forEach(function (t) {
+        t.addEventListener('click', function () {
+            var card = t.closest('.open-card');
+            if (!card) return;
+            // 以当前卡片目标状态为准，同步所有卡片
+            setAllExpanded(!card.classList.contains('expanded'));
+        });
+    });
+
     // 描述两行省略 + 「更多>>」展开/收起（无溢出时不渲染占位，不占用空间）
     function applyClamp() {
         var descs = list.querySelectorAll('.open-desc');


### PR DESCRIPTION
- 新增手机端每卡片右下角展开/收起箭头，与源码/文档/演示链接同行并右对齐
- 收起态隐藏作者/语言/协议/标签，展开再显示（全局同步）
- 卡片 padding 收紧：全局 16px，手机端 8px、底部 6px

## PR Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

**Please read and check followings before submitting a PR.**

- [ ] The changes have been tested (for bug fixes / features).
- [x] Others (Update, Documentation, Translation, etc...)

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [ ] Feature.
- [x] Improvement.
- [ ] Code style update (e.g. formatting).
- [ ] Refactoring (no changes to functionality and APIs).
- [ ] Documentation.
- [ ] Translation.
- [ ] Version Upgrade.
- [ ] Other... Please describe:
