### PR TITLE
Add: 开源页支持标签筛选与 URL 状态同步

### DIFF
--- a/languages/en.yml
+++ b/languages/en.yml
@@ -46,6 +46,7 @@ open:
   prev: Previous page
   next: Next page
   pagination: Pagination
+  filter: Filter by tag
 
 introduction:
   landscape: A brand new default theme for Hexo.

--- a/languages/zh-CN.yml
+++ b/languages/zh-CN.yml
@@ -46,6 +46,7 @@ open:
   prev: 上一页
   next: 下一页
   pagination: 分页
+  filter: 按标签筛选
 
 introduction:
   landscape: Hexo 中的一个全新的默认主题，需要 Hexo 2.4 或者 更高的版本。

--- a/layout/open.ejs
+++ b/layout/open.ejs
@@ -1,5 +1,8 @@
 <% const openDisplay = page.display || theme.open.display || 'grid'; %>
 <% const openPageSize = page.page_size || theme.open.page_size || 0; %>
+<%# 开源项目数据：source/_data/open/*.yml 单文件配置，文件名即 key（如 open/diversity-comments-site），按 order 升序；提前计算供 标签筛选栏 与 列表 共用 %>
+<% const openData = site.data || {}; %>
+<% const projects = Object.keys(openData).filter(function (k) { return k.indexOf('open/') === 0; }).map(function (k) { var p = Object.assign({}, openData[k]); p.key = k.slice(5); return p; }).sort(function (a, b) { return (a.order || 0) - (b.order || 0); }); %>
 <div id="content-wrap" class="open-page">
     <div id="content" class="wrapper">
         <div id="content-inner">
@@ -27,14 +30,22 @@
                                     </div>
                                 </div>
                             </header>
+                            <%# 标签筛选栏：仅展示被 ≥2 个项目使用的「常用标签」（次数降序、同名升序），点击与搜索取交集；卡片内标签也可点击筛选 %>
+                            <% var tagCount = {}; %>
+                            <% projects.forEach(function (p) { (p.tags || []).forEach(function (t) { tagCount[t] = (tagCount[t] || 0) + 1; }); }); %>
+                            <% var hotTags = Object.keys(tagCount).filter(function (t) { return tagCount[t] >= 2; }).sort(function (a, b) { return tagCount[b] - tagCount[a] || a.localeCompare(b); }); %>
+                            <% if (hotTags.length) { %>
+                            <div class="open-tagbar" role="group" aria-label="<%= __('open.filter') %>">
+                                <% hotTags.forEach(function (t) { %>
+                                <button type="button" class="open-tagchip" data-tag="<%= t %>" aria-pressed="false"><%= t %><span class="open-tagchip-n"><%= tagCount[t] %></span></button>
+                                <% }); %>
+                            </div>
+                            <% } %>
                             <p class="open-status" data-result="<%= __('open.result') %>" role="status" aria-live="polite" hidden></p>
                             <div id="open-list" class="open-<%= openDisplay %>" data-more="<%= __('open.more') %>" data-collapse="<%= __('open.collapse') %>" data-page-size="<%= openPageSize %>">
-                                <%# 开源项目数据：source/_data/open/*.yml 单文件配置，文件名即 key（如 open/diversity-comments-site），按 order 升序 %>
-                                <% const openData = site.data || {}; %>
-                                <% const projects = Object.keys(openData).filter(function (k) { return k.indexOf('open/') === 0; }).map(function (k) { var p = Object.assign({}, openData[k]); p.key = k.slice(5); return p; }).sort(function (a, b) { return (a.order || 0) - (b.order || 0); }); %>
                                 <% projects.forEach(function (p) { %>
                                 <% var sp = [p.key, p.name, p.description, p.author, p.license]; if (p.language) sp = sp.concat(Array.isArray(p.language) ? p.language : [p.language]); if (p.tags) sp = sp.concat(p.tags); %>
-                                <div class="open-card" data-search="<%= sp.filter(Boolean).join(' ') %>">
+                                <div class="open-card" data-search="<%= sp.filter(Boolean).join(' ') %>" data-tags="<%= (p.tags || []).join('|') %>">
                                     <div class="open-card-head">
                                         <% if (p.logo) { %><img class="open-logo" src="<%= p.logo %>" alt="<%= p.name %>" loading="lazy"><% } else { %><svg class="open-logo open-logo-default" viewBox="0 0 100 100" aria-hidden="true"><rect width="100" height="100" rx="20" fill="var(--content-bg-color)" stroke="var(--text-color)" stroke-width="3" stroke-opacity="0.3"/><text x="50" y="50" dy="0.35em" text-anchor="middle" font-size="52" font-weight="bold" fill="var(--text-color)" font-family="system-ui, -apple-system, sans-serif"><%= (p.name || '?').trim().charAt(0).toUpperCase() %></text></svg><% } %>
                                         <h3 class="open-name"><%= p.name %></h3>
@@ -47,7 +58,7 @@
                                             <% if (p.language) { %><% var langs = Array.isArray(p.language) ? p.language : [p.language]; %><span class="open-badge open-badge-lang"><span class="open-badge-label"><%= __('open.language') %></span><% langs.forEach(function (lang) { %><span class="open-badge-value"><%= lang %></span><% }); %></span><% } %>
                                             <% if (p.license) { %><% var licUrl = p.license_url || (p.source ? p.source + '/blob/main/LICENSE' : ''); %><% if (licUrl) { %><a class="open-badge-link" href="<%= licUrl %>" target="_blank" rel="noopener"><% } %><span class="open-badge open-badge-license"><span class="open-badge-label"><%= __('open.license') %></span><span class="open-badge-value"><%= p.license %></span></span><% if (licUrl) { %></a><% } %><% } %>
                                         </div>
-                                        <% if (p.tags && p.tags.length) { %><div class="open-tags"><% p.tags.forEach(function (t) { %><span class="open-tag"><%= t %></span><% }); %></div><% } %>
+                                        <% if (p.tags && p.tags.length) { %><div class="open-tags"><% p.tags.forEach(function (t) { %><button type="button" class="open-tag" data-tag="<%= t %>" aria-label="<%= __('open.filter') %>: <%= t %>"><%= t %></button><% }); %></div><% } %>
                                         <div class="open-links">
                                             <% if (p.source) { %><a class="open-link" href="<%= p.source %>" target="_blank" rel="noopener"><%= __('open.source') %></a><% } %>
                                             <% if (p.demo) { %><a class="open-link" href="<%= p.demo %>" target="_blank" rel="noopener"><%= __('open.demo') %></a><% } %>

--- a/source/css/_partial/open.styl
+++ b/source/css/_partial/open.styl
@@ -190,9 +190,68 @@
     font-size 0.75em
     padding 2px 8px
     margin 0 6px 6px 0
+    border none
     border-radius 10px
     background-color color-pale-gray
     color color-dark-gray
+    font-family font-page
+    cursor pointer
+    transition all 0.2s
+    user-select none
+    -webkit-tap-highlight-color transparent
+    &:hover
+        background-color color-link
+        color #fff
+
+// 标签筛选栏：常用标签 chips（被 ≥2 个项目使用的标签），与 .open-tagchip 同风格单选高亮
+.open-tagbar
+    display flex
+    flex-wrap wrap
+    align-items center
+    gap 8px
+    max-width 1600px
+    margin 0 auto 12px
+
+.open-tagchip
+    font-family font-page
+    font-size 0.8em
+    line-height 1
+    padding 6px 12px
+    display inline-flex
+    align-items center
+    gap 6px
+    border 1px solid var(--header-divider-color)
+    border-radius 999px
+    background-color var(--content-bg-color)
+    color var(--text-color)
+    cursor pointer
+    transition all 0.2s
+    user-select none
+    -webkit-tap-highlight-color transparent
+    .open-tagchip-n
+        font-size 0.85em
+        opacity 0.55
+    // 选中态 × 删除图标：由 open.js 选中时注入（count 徽标让位隐藏）
+    .open-tagchip-x
+        display none
+        align-items center
+        margin-left -2px
+        svg
+            display block
+            width 12px
+            height 12px
+    &:hover
+        border-color color-link
+        color color-link
+    &.active
+        border-color color-link
+        background-color color-link
+        color #fff
+        .open-tagchip-n
+            display none
+        .open-tagchip-x
+            display inline-flex
+            opacity 0.85
 
 .open-links
     display flex
@@ -507,6 +566,13 @@
         padding 7px 30px
     .open-status
         margin-bottom 8px
+    // 标签筛选栏：手机端紧凑化
+    .open-tagbar
+        gap 6px
+        margin-bottom 8px
+    .open-tagchip
+        font-size 0.75em
+        padding 5px 10px
     // 分页：手机端按钮紧凑化
     .open-pagination
         margin 16px auto 8px

--- a/source/js/open.js
+++ b/source/js/open.js
@@ -59,6 +59,11 @@
     var clearBtn = list.parentNode.querySelector('.open-search-clear');
     var status = list.parentNode.querySelector('.open-status');
     var noResult = list.parentNode.querySelector('.open-no-result');
+    // 标签筛选：activeTag 单选（再次点击取消），与搜索关键词取交集
+    var tagbar = list.parentNode.querySelector('.open-tagbar');
+    var activeTag = '';
+    // 筛选栏中动态补充的 chip（点击卡片标签筛选时，该标签可能不在常用标签栏里）
+    var dynamicChip = null;
     // 参与高亮的元素：缓存原始文本，避免高亮标签叠加
     var marks = [];
     cards.forEach(function (card) {
@@ -97,7 +102,71 @@
         return out + escapeHtml(buf) + (on ? '</mark>' : '');
     }
 
-    function applySearch() {
+    // 筛选栏 chip 高亮同步：选中态把 count 徽标换成 ×（点击 × 直接删除筛选并清理 URL）；
+    // 当前选中标签不在筛选栏时（点击卡片标签筛选的场景），动态补一个可删除的 chip
+    var X_SVG = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" aria-hidden="true"><path d="M6 6l12 12M18 6L6 18"/></svg>';
+    function syncTagbar() {
+        if (!tagbar) return;
+        // 移除上一轮的动态 chip，避免重复累积
+        if (dynamicChip && dynamicChip.parentNode) dynamicChip.parentNode.removeChild(dynamicChip);
+        dynamicChip = null;
+        var known = false;
+        tagbar.querySelectorAll('.open-tagchip').forEach(function (chip) {
+            if (chip.getAttribute('data-tag') === activeTag) known = true;
+        });
+        if (activeTag && !known) {
+            dynamicChip = document.createElement('button');
+            dynamicChip.type = 'button';
+            dynamicChip.className = 'open-tagchip';
+            dynamicChip.setAttribute('data-tag', activeTag);
+            dynamicChip.innerHTML = escapeHtml(activeTag);
+            tagbar.appendChild(dynamicChip);
+        }
+        tagbar.querySelectorAll('.open-tagchip').forEach(function (chip) {
+            var on = chip.getAttribute('data-tag') === activeTag;
+            chip.classList.toggle('active', on);
+            chip.setAttribute('aria-pressed', on ? 'true' : 'false');
+            var x = chip.querySelector('.open-tagchip-x');
+            if (on && !x) {
+                x = document.createElement('span');
+                x.className = 'open-tagchip-x';
+                x.setAttribute('aria-hidden', 'true');
+                x.innerHTML = X_SVG;
+                chip.appendChild(x);
+            } else if (!on && x) {
+                x.parentNode.removeChild(x);
+            }
+        });
+    }
+
+    // URL 同步（③）：?q=搜索词&tag=标签；replaceState 不产生历史记录，刷新/分享可还原，前进后退由 popstate 处理
+    function writeUrl() {
+        if (!window.URLSearchParams || !window.history || !history.replaceState) return;
+        var params = new URLSearchParams(location.search);
+        if (input.value.trim()) params.set('q', input.value.trim()); else params.delete('q');
+        if (activeTag) params.set('tag', activeTag); else params.delete('tag');
+        var qs = params.toString();
+        history.replaceState(null, '', location.pathname + (qs ? '?' + qs : '') + location.hash);
+    }
+
+    // 从 URL 还原 搜索词/标签（仅接受卡片真实存在的标签，避免无效值）
+    function initFromUrl() {
+        if (!window.URLSearchParams) return;
+        var params = new URLSearchParams(location.search);
+        input.value = params.get('q') || '';
+        activeTag = '';
+        var tag = params.get('tag') || '';
+        if (tag) {
+            // cards 是 NodeList，无 some 方法，借用 Array.prototype
+            var valid = Array.prototype.some.call(cards, function (c) {
+                return (c.dataset.tags || '').split('|').indexOf(tag) !== -1;
+            });
+            if (valid) activeTag = tag;
+        }
+        syncTagbar();
+    }
+
+    function applySearch(animate) {
         var value = (input.value || '').toLowerCase().trim();
         var tokens = value ? value.split(/\s+/) : [];
         var matched = 0;
@@ -105,6 +174,8 @@
         cards.forEach(function (card) {
             var text = (card.dataset.search || '').toLowerCase();
             var ok = tokens.every(function (tk) { return text.indexOf(tk) !== -1; });
+            // 标签筛选与关键词取交集
+            if (ok && activeTag) ok = (card.dataset.tags || '').split('|').indexOf(activeTag) !== -1;
             // 只记录命中标记，是否隐藏（未命中 / 不在当前页）统一交给 applyPage 处理
             card.dataset.match = ok ? '1' : '0';
             if (ok) matched++;
@@ -116,15 +187,19 @@
 
         if (clearBtn) clearBtn.hidden = !value;
         if (status) {
-            status.hidden = !tokens.length;
+            // 有关键词或选中标签即展示结果计数
+            var filtering = tokens.length > 0 || !!activeTag;
+            status.hidden = !filtering;
             // 占位符用 {n}：hexo 的 __() 会把 %s 立即格式化掉
-            if (tokens.length) status.textContent = (status.dataset.result || '{n}').replace('{n}', matched);
+            if (filtering) status.textContent = (status.dataset.result || '{n}').replace('{n}', matched);
         }
-        if (noResult) noResult.hidden = !(tokens.length && !matched);
+        if (noResult) noResult.hidden = !((tokens.length || activeTag) && !matched);
 
+        // 状态写入 URL
+        writeUrl();
         // 新搜索从头翻页
         currentPage = 1;
-        applyPage();
+        applyPage(animate);
     }
 
     if (input) {
@@ -134,7 +209,14 @@
             timer = setTimeout(applySearch, 100);
         });
         input.addEventListener('keydown', function (e) {
-            if (e.key === 'Escape' && input.value) { input.value = ''; applySearch(); input.blur(); }
+            // Esc：有关键词清关键词，仅有标签清标签（清空并失焦）
+            if (e.key === 'Escape' && (input.value || activeTag)) {
+                input.value = '';
+                activeTag = '';
+                syncTagbar();
+                applySearch();
+                input.blur();
+            }
         });
     }
     if (clearBtn) {
@@ -144,9 +226,11 @@
             input.focus();
         });
     }
-    // 清空搜索并回到完整列表（清除按钮 / 无结果重置按钮共用）
+    // 清空搜索与标签并回到完整列表（清除按钮 / 无结果重置按钮共用）
     function resetSearch() {
         input.value = '';
+        activeTag = '';
+        syncTagbar();
         applySearch();
         replayCardAnim();
     }
@@ -157,6 +241,34 @@
             input.focus();
         });
     }
+    // 标签筛选入口（①）：筛选栏 chip 与卡片内标签均可触发；事件委托读 data-tag，标签高亮重绘不影响
+    function toggleTag(tag) {
+        activeTag = activeTag === tag ? '' : tag;
+        syncTagbar();
+        applySearch(true);
+    }
+    if (tagbar) {
+        tagbar.addEventListener('click', function (e) {
+            var chip = e.target.closest('.open-tagchip');
+            if (!chip) return;
+            // × 仅负责删除筛选（清空 activeTag 并同步清理 URL）
+            if (e.target.closest('.open-tagchip-x')) {
+                activeTag = '';
+                syncTagbar();
+                applySearch(true);
+                return;
+            }
+            toggleTag(chip.getAttribute('data-tag'));
+        });
+    }
+    list.addEventListener('click', function (e) {
+        var tag = e.target.closest('.open-tag');
+        if (!tag || !tag.getAttribute('data-tag')) return;
+        var wasActive = activeTag === tag.getAttribute('data-tag');
+        toggleTag(tag.getAttribute('data-tag'));
+        // 选中新标签时回到列表顶部，便于查看筛选结果；取消选中不动
+        if (!wasActive && activeTag) list.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
     // 快捷键：/ 聚焦搜索框（输入类元素聚焦时不抢占），Esc 清空并失焦
     if (input) {
         document.addEventListener('keydown', function (e) {
@@ -318,7 +430,13 @@
 
     window.addEventListener('resize', function () { requestAnimationFrame(applyGridCols); requestAnimationFrame(applyClamp); });
     window.addEventListener('load', function () { requestAnimationFrame(applyClamp); });
+    // 浏览器前进/后退时按 URL 还原筛选状态
+    window.addEventListener('popstate', function () {
+        initFromUrl();
+        applySearch();
+    });
     applyGridCols();
-    // 初次加载播一次入场动画
-    applyPage(true);
+    // 从 URL 还原 搜索词/标签（?q= & ?tag=），初次加载播一次入场动画
+    initFromUrl();
+    applySearch(true);
 })();


### PR DESCRIPTION
- 标题行下新增常用标签筛选栏（仅展示被 ≥2 个项目使用的标签，带项目数徽标），选中态 count 换 × 一键删除并同步清理 URL
- 卡片内标签可点击筛选，非热点标签动态补可删除 chip；与搜索关键词取交集
- 筛选状态经 ?q=&tag= 写入/还原（replaceState 不产生历史），支持前进后退与分享直达
- 无结果重置与 Esc 同时清空关键词与标签；新增中英文案 open.filter

## PR Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

**Please read and check followings before submitting a PR.**

- [x] The changes have been tested (for bug fixes / features).
- [ ] Others (Update, Documentation, Translation, etc...)

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Improvement.
- [ ] Code style update (e.g. formatting).
- [ ] Refactoring (no changes to functionality and APIs).
- [ ] Documentation.
- [ ] Translation.
- [ ] Version Upgrade.
- [ ] Other... Please describe:
