### PR TITLE
Mod: 开源页标签筛选栏上下间距对齐

### DIFF
--- a/layout/open.ejs
+++ b/layout/open.ejs
@@ -3,6 +3,10 @@
 <%# 开源项目数据：source/_data/open/*.yml 单文件配置，文件名即 key（如 open/diversity-comments-site），按 order 升序；提前计算供 标签筛选栏 与 列表 共用 %>
 <% const openData = site.data || {}; %>
 <% const projects = Object.keys(openData).filter(function (k) { return k.indexOf('open/') === 0; }).map(function (k) { var p = Object.assign({}, openData[k]); p.key = k.slice(5); return p; }).sort(function (a, b) { return (a.order || 0) - (b.order || 0); }); %>
+<%# 常用标签：被 ≥2 个项目使用的标签（次数降序、同名升序），有则给 header 加 has-tagbar 类以收掉其 20px 下内边距 %>
+<% var tagCount = {}; %>
+<% projects.forEach(function (p) { (p.tags || []).forEach(function (t) { tagCount[t] = (tagCount[t] || 0) + 1; }); }); %>
+<% var hotTags = Object.keys(tagCount).filter(function (t) { return tagCount[t] >= 2; }).sort(function (a, b) { return tagCount[b] - tagCount[a] || a.localeCompare(b); }); %>
 <div id="content-wrap" class="open-page">
     <div id="content" class="wrapper">
         <div id="content-inner">
@@ -10,7 +14,7 @@
                 <div class="article-inner">
                     <div class="article">
                         <div class="inner">
-                            <header class="article-header">
+                            <header class="article-header<%= hotTags.length ? ' has-tagbar' : '' %>">
                                 <div class="open-title-row">
                                     <h1 class="article-title" itemprop="name"><svg class="open-title-ico" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M9.4 16.6 4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0L20 12l-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"/></svg><span><%= __('open.title') %></span></h1>
                                     <div class="open-search">
@@ -30,10 +34,7 @@
                                     </div>
                                 </div>
                             </header>
-                            <%# 标签筛选栏：仅展示被 ≥2 个项目使用的「常用标签」（次数降序、同名升序），点击与搜索取交集；卡片内标签也可点击筛选 %>
-                            <% var tagCount = {}; %>
-                            <% projects.forEach(function (p) { (p.tags || []).forEach(function (t) { tagCount[t] = (tagCount[t] || 0) + 1; }); }); %>
-                            <% var hotTags = Object.keys(tagCount).filter(function (t) { return tagCount[t] >= 2; }).sort(function (a, b) { return tagCount[b] - tagCount[a] || a.localeCompare(b); }); %>
+                            <%# 标签筛选栏：点击与搜索取交集；卡片内标签也可点击筛选 %>
                             <% if (hotTags.length) { %>
                             <div class="open-tagbar" role="group" aria-label="<%= __('open.filter') %>">
                                 <% hotTags.forEach(function (t) { %>

--- a/source/css/_partial/open.styl
+++ b/source/css/_partial/open.styl
@@ -204,13 +204,18 @@
         color #fff
 
 // 标签筛选栏：常用标签 chips（被 ≥2 个项目使用的标签），与 .open-tagchip 同风格单选高亮
+// 有筛选栏时（open.ejs 注入 has-tagbar 类）收掉 article-header 的 20px 下内边距，
+// 间距统一由 tagbar 自身 margin 控制；无筛选栏的页面保持原间距不受影响
+.open-page .article-header.has-tagbar
+    padding-bottom 0
 .open-tagbar
     display flex
     flex-wrap wrap
     align-items center
     gap 8px
     max-width 1600px
-    margin 0 auto 12px
+    // 上 4px（+标题行 8px 行间距 = 12）与下 12px 对齐
+    margin 4px auto 12px
 
 .open-tagchip
     font-family font-page
@@ -566,10 +571,10 @@
         padding 7px 30px
     .open-status
         margin-bottom 8px
-    // 标签筛选栏：手机端紧凑化
+    // 标签筛选栏：手机端紧凑化（搜索框 margin-bottom 12px 在 grid 行内，与下方 12px 对齐）
     .open-tagbar
         gap 6px
-        margin-bottom 8px
+        margin 0 0 12px
     .open-tagchip
         font-size 0.75em
         padding 5px 10px


### PR DESCRIPTION
- 有常用标签筛选栏时给 article-header 注入 has-tagbar 类并收掉其 20px 下内边距（EJS 构建期判断，替代 :has 选择器，全浏览器可用）
- 筛选栏 margin 调整为上 4px 下 12px（上方计入标题行 8px 行间距），与下方 12px 对齐
- 手机端筛选栏 margin 统一为 12px，与搜索框 grid 行间距对称

## PR Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

**Please read and check followings before submitting a PR.**

- [ ] The changes have been tested (for bug fixes / features).
- [x] Others (Update, Documentation, Translation, etc...)

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [ ] Feature.
- [ ] Improvement.
- [ ] Code style update (e.g. formatting).
- [x] Refactoring (no changes to functionality and APIs).
- [ ] Documentation.
- [ ] Translation.
- [ ] Version Upgrade.
- [ ] Other... Please describe:
