### PR TITLE
Mod: 手机端顶部明暗切换按钮与汉堡菜单边缘间距对称

### DIFF
--- a/source/css/_partial/header.styl
+++ b/source/css/_partial/header.styl
@@ -135,6 +135,10 @@ transition = all 0.4s cubic-bezier(0.68, -0.55, 0.27, 1.55)
         bottom 0
         right gutter-width
         margin auto
+        // 图标右对齐（去 UA 默认 padding），使字形右缘 = gutter-width，
+        // 与左侧汉堡菜单条距左 gutter-width 视觉对称；按钮点击热区仍为 60px
+        padding 0
+        text-align right
 
 .color-scheme-icon
     font-size 1.5rem


### PR DESCRIPTION
- 手机端 color-scheme-toggle 去 UA 默认 padding 并将图标改为右对齐，字形右缘精确等于 gutter-width（20px），与左侧汉堡菜单条距左 20px 视觉对称
- 按钮点击热区保持 60px 不变，PC 端不受影响

## PR Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

**Please read and check followings before submitting a PR.**

- [ ] The changes have been tested (for bug fixes / features).
- [x] Others (Update, Documentation, Translation, etc...)

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [ ] Feature.
- [x] Improvement.
- [ ] Code style update (e.g. formatting).
- [ ] Refactoring (no changes to functionality and APIs).
- [ ] Documentation.
- [ ] Translation.
- [ ] Version Upgrade.
- [ ] Other... Please describe:
