### PR TITLE
Mod: 开源页无结果区改为卡片式空状态布局

### DIFF
--- a/languages/en.yml
+++ b/languages/en.yml
@@ -41,6 +41,7 @@ open:
   result: Found {n} projects
   no_result: No matching projects found
   reset: Reset
+  no_result_tip: Try different keywords or clear the filters
   more: More>>
   collapse: Collapse
   prev: Previous page

--- a/languages/zh-CN.yml
+++ b/languages/zh-CN.yml
@@ -41,6 +41,7 @@ open:
   result: 找到 {n} 个项目
   no_result: 未找到匹配的开源项目
   reset: 重置
+  no_result_tip: 试试更换关键词或清除筛选条件
   more: 更多>>
   collapse: 收起
   prev: 上一页

--- a/layout/open.ejs
+++ b/layout/open.ejs
@@ -74,8 +74,22 @@
                                 <% if (!projects.length) { %><p class="open-empty"><%= __('open.empty') %></p><% } %>
                             </div>
                             <div class="open-no-result" hidden>
-                                <p class="open-empty"><%= __('open.no_result') %></p>
-                                <button class="open-reset" type="button"><%= __('open.reset') %></button>
+                                <%# 空状态卡片：插画居左 + 文案按钮居右，与项目卡片同风格；颜色走 currentColor 跟随明暗主题 %>
+                                <svg class="open-no-ico" viewBox="0 0 120 96" fill="none" aria-hidden="true" focusable="false">
+                                    <rect x="14" y="6" width="76" height="56" rx="8" stroke="currentColor" stroke-width="1.5" stroke-dasharray="4 4" opacity="0.45"/>
+                                    <rect x="24" y="18" width="40" height="6" rx="3" fill="currentColor" opacity="0.22"/>
+                                    <rect x="24" y="32" width="56" height="6" rx="3" fill="currentColor" opacity="0.22"/>
+                                    <rect x="24" y="46" width="26" height="6" rx="3" fill="currentColor" opacity="0.16"/>
+                                    <circle cx="78" cy="52" r="15" stroke="currentColor" stroke-width="3" opacity="0.8"/>
+                                    <circle cx="78" cy="52" r="2" fill="currentColor" opacity="0.5"/>
+                                    <circle cx="78" cy="52" r="7.5" fill="currentColor" opacity="0.12"/>
+                                    <path d="M89.5 63.5 L103 77" stroke="currentColor" stroke-width="4.5" stroke-linecap="round" opacity="0.8"/>
+                                </svg>
+                                <div class="open-no-body">
+                                    <p class="open-empty"><%= __('open.no_result') %></p>
+                                    <p class="open-empty-tip"><%= __('open.no_result_tip') %></p>
+                                    <button class="open-reset" type="button"><%= __('open.reset') %></button>
+                                </div>
                             </div>
                             <%# 分页按钮由 open.js 动态渲染；page_size 为 0 或仅一页时保持隐藏 %>
                             <nav id="open-pagination" class="open-pagination" data-prev="<%= __('open.prev') %>" data-next="<%= __('open.next') %>" aria-label="<%= __('open.pagination') %>" hidden></nav>

--- a/source/css/_partial/open.styl
+++ b/source/css/_partial/open.styl
@@ -280,15 +280,62 @@
         display none
 
 // 搜索无结果容器：文案 + 重置按钮纵向居中
+// 空状态卡片：与项目卡片同风格（同底色/边框/圆角），插画居左 + 文案按钮居右，
+// 避免三元素松散悬浮在空白里
 .open-no-result
     display flex
-    flex-direction column
     align-items center
-    gap 12px
+    gap 20px
+    // border-box：主题全局 content-box，不显式声明的话 max-width 不含 padding/border，
+    // 实际渲染宽度会多出 74px（400 → 474）
+    box-sizing border-box
+    max-width 400px
+    margin 24px auto 0
+    padding 32px 36px
+    background-color var(--content-bg-color)
+    border 1px solid var(--header-divider-color)
+    border-radius 8px
     &[hidden]
         display none
-    .open-empty
-        padding 32px 0 0
+    // 空状态插画：颜色走 currentColor 跟随明暗主题，轻微上下浮动
+    .open-no-ico
+        width 88px
+        height auto
+        flex-shrink 0
+        color var(--text-color)
+    .open-no-body
+        display flex
+        flex-direction column
+        align-items flex-start
+        gap 10px
+        min-width 0
+        // 文案颜色必须显式跟 var(--text-color)：open 页不走 .article-content，无结果区
+        // 会继承浏览器默认黑色，暗色下黑字贴 #444 卡片底不可见；层次靠 粗细+透明度 区分
+        .open-empty
+            padding 0
+            margin 0
+            font-weight bold
+            color var(--text-color)
+        .open-empty-tip
+            padding 0
+            margin 0
+            font-size 0.85em
+            color var(--text-color)
+            opacity 0.7
+
+// 插画浮动动画（尊重系统减弱动态效果设置）
+@keyframes open-no-float
+    0%, 100%
+        transform translateY(0)
+    50%
+        transform translateY(-3px)
+
+.open-no-ico
+    animation open-no-float 3s ease-in-out infinite
+
+@media (prefers-reduced-motion: reduce)
+    .open-no-ico
+        animation none
 
 // 无结果重置按钮：与分页按钮同风格，宽度自适应文案
 .open-reset
@@ -299,7 +346,8 @@
     display inline-flex
     align-items center
     justify-content center
-    border 1px solid var(--header-divider-color)
+    // 边框用中灰：明暗模式下与卡片底色（白/#444）都有对比，避免按钮融入卡片
+    border 1px solid color-gray
     border-radius 8px
     background-color var(--content-bg-color)
     color var(--text-color)
@@ -571,6 +619,15 @@
         padding 7px 30px
     .open-status
         margin-bottom 8px
+    // 空状态卡片：手机端紧凑化（比桌面端略收，但保留足够高度避免扁宽）
+    .open-no-result
+        gap 14px
+        margin-top 16px
+        padding 30px 24px
+        .open-no-ico
+            width 64px
+        .open-no-body
+            gap 8px
     // 标签筛选栏：手机端紧凑化（搜索框 margin-bottom 12px 在 grid 行内，与下方 12px 对齐）
     .open-tagbar
         gap 6px


### PR DESCRIPTION
- 空状态改为与项目卡片同风格的横排卡片：插画居左 + 主文案/副文案/重置按钮居右
- 新增放大镜 + 虚线空卡片 SVG 插画，currentColor 跟随明暗主题，3s 浮动动画（尊重 prefers-reduced-motion）
- 新增 i18n 文案 no_result_tip（中英文同步）
- 文案颜色显式 var(--text-color)：修复 open 页不走 .article-content 导致副文案恒黑、暗色下不可见
- 重置按钮边框用中灰，明暗模式下与卡片底色均有对比
- 卡片 border-box + max-width 400px + padding 32/36（手机端 30/24），精确控制比例避免扁宽

## PR Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

**Please read and check followings before submitting a PR.**

- [x] The changes have been tested (for bug fixes / features).
- [x] Others (Update, Documentation, Translation, etc...)

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [x] Improvement.
- [ ] Code style update (e.g. formatting).
- [ ] Refactoring (no changes to functionality and APIs).
- [ ] Documentation.
- [ ] Translation.
- [ ] Version Upgrade.
- [ ] Other... Please describe:
