### PR TITLE
Add: 开源页筛选行标签折叠为「+N」并优化绕排布局

### DIFF
--- a/languages/en.yml
+++ b/languages/en.yml
@@ -52,6 +52,8 @@ open:
   sort_default: Default
   sort_name_asc: Name ↑
   sort_name_desc: Name ↓
+  tags_more: Show all tags
+  tags_less: Collapse tags
 
 introduction:
   landscape: A brand new default theme for Hexo.

--- a/languages/zh-CN.yml
+++ b/languages/zh-CN.yml
@@ -52,6 +52,8 @@ open:
   sort_default: 默认
   sort_name_asc: 名称 ↑
   sort_name_desc: 名称 ↓
+  tags_more: 展开全部标签
+  tags_less: 收起标签
 
 introduction:
   landscape: Hexo 中的一个全新的默认主题，需要 Hexo 2.4 或者 更高的版本。

--- a/layout/open.ejs
+++ b/layout/open.ejs
@@ -35,19 +35,23 @@
                                     </div>
                                 </div>
                             </header>
-                            <%# 筛选栏：常用标签 chips 居左 + 排序下拉靠右（同一行）；点击标签与搜索取交集，卡片内标签也可点击筛选。
-                                始终渲染——排序控件常驻，无常用标签时该行只剩排序下拉 %>
+                            <%# 筛选栏：常用标签 chips 居左 + 右侧控件组（折叠按钮 + 排序下拉）靠右；
+                                点击标签与搜索取交集，卡片内标签也可点击筛选。
+                                始终渲染——排序控件常驻，无常用标签时该行只剩排序下拉。
+                                控件组在 DOM 中前置于标签行、浮动到右上角，标签行为块级、chip 为行内级：
+                                第一行标签自动避让控件，其后的行占满整行，标签按自身宽度密排不留大片空白。
+                                标签过多时由 open.js 折叠为「+N」（展开/收起文案经 data 属性注入） %>
                             <div class="open-filterbar">
-                                <div class="open-tagbar"<% if (hotTags.length) { %> role="group" aria-label="<%= __('open.filter') %>"<% } %>>
-                                    <% hotTags.forEach(function (t) { %>
-                                    <button type="button" class="open-tagchip" data-tag="<%= t %>" aria-pressed="false"><%= t %><span class="open-tagchip-n"><%= tagCount[t] %></span></button>
-                                    <% }); %>
+                                <%# 控件组：折叠「+N」按钮（由 open.js 注入到本组内、排序下拉之前）+ 排序下拉 %>
+                                <div class="open-filter-tools">
+                                    <select class="open-sort" aria-label="<%= __('open.sort') %>">
+                                        <option value="order"><%= __('open.sort_default') %></option>
+                                        <option value="name"><%= __('open.sort_name_asc') %></option>
+                                        <option value="name_desc"><%= __('open.sort_name_desc') %></option>
+                                    </select>
                                 </div>
-                                <select class="open-sort" aria-label="<%= __('open.sort') %>">
-                                    <option value="order"><%= __('open.sort_default') %></option>
-                                    <option value="name"><%= __('open.sort_name_asc') %></option>
-                                    <option value="name_desc"><%= __('open.sort_name_desc') %></option>
-                                </select>
+                                <%# chip 之间不能有空白字符：行内级元素之间的空白会叠加成额外间隙（间距改由 chip 自身 margin 提供） %>
+                                <div class="open-tagbar" data-more-label="<%= __('open.tags_more') %>" data-less-label="<%= __('open.tags_less') %>"<% if (hotTags.length) { %> role="group" aria-label="<%= __('open.filter') %>"<% } %>><% hotTags.forEach(function (t) { %><button type="button" class="open-tagchip" data-tag="<%= t %>" aria-pressed="false"><%= t %><span class="open-tagchip-n"><%= tagCount[t] %></span></button><% }); %></div>
                             </div>
                             <p class="open-status" data-result="<%= __('open.result') %>" role="status" aria-live="polite" hidden></p>
                             <div id="open-list" class="open-<%= openDisplay %>" data-more="<%= __('open.more') %>" data-collapse="<%= __('open.collapse') %>" data-page-size="<%= openPageSize %>">

--- a/source/css/_partial/open.styl
+++ b/source/css/_partial/open.styl
@@ -74,10 +74,13 @@
         .open-ico
             fill #fff
 
-// 排序下拉：位于筛选栏行内、靠右；尺寸与标签 chip 对齐，避免把该行撑高；默认 order 不写入 URL
+// 排序下拉：位于筛选栏行内、靠右；默认 order 不写入 URL
+// 筛选行三种控件（.open-tagchip / .open-tagbar-more / .open-sort）必须等高：PC 30px、手机 28px
+// —— 高度一律用显式 height + border-box 定死，垂直 padding 归零，改一处需同步另外两处
 .open-sort
     font-family font-page
     font-size 0.8em
+    box-sizing border-box
     height 30px
     padding 0 6px
     border 1px solid var(--header-divider-color)
@@ -220,25 +223,34 @@
         color #fff
 
 // 筛选栏行：常用标签 chips（被 ≥2 个项目使用的标签，与 .open-tagchip 同风格单选高亮）居左 +
-// 排序下拉靠右，同一行展示。该行由 open.ejs 恒渲染（无常用标签时只剩排序下拉），
+// 右侧控件组（折叠按钮 + 排序下拉）靠右。该行由 open.ejs 恒渲染（无常用标签时只剩排序下拉），
 // 故 has-tagbar 常驻：收掉 article-header 的 20px 下内边距，间距统一由本行 margin 控制
 .open-page .article-header.has-tagbar
     padding-bottom 0
+// 控件组浮动到右上（DOM 中前置于标签行）→ 标签行为块级行内流：首行避让控件宽度，
+// 第二行起占满整行，标签按自身宽度密排，窄屏下不再出现大片空白。
+// overflow hidden 负责包住浮动（行高正确，也不会压住下方元素）
 .open-filterbar
-    display flex
-    align-items center
-    gap 8px
+    display block
+    overflow hidden
     max-width 1600px
     // 上 4px（+标题行 8px 行间距 = 12）与下 12px 对齐
     margin 4px auto 12px
+// 标签行：块级容器 + 行内级 chip（间距由 chip 自身 margin 提供，行内布局没有 gap）
 .open-tagbar
+    display block
+    // 抵消最后一行 chip 的下外边距，避免尾部多出空白
+    margin-bottom -8px
+    // is-collapsed 仅作状态标记（open.js 维护）：折叠时多余 chip 已隐藏，该行恒为一行高
+// 控件组：折叠按钮（open.js 注入到本组首位）+ 排序下拉，二者恒在同一行；
+// 浮动到右上后标签自动绕排，标签展开成多行时控件也不会被挤走
+.open-filter-tools
     display flex
-    flex-wrap wrap
     align-items center
     gap 8px
-    // 占满剩余宽度，把排序下拉挤到行尾；min-width 0 允许窄屏下收缩换行
-    flex 1 1 auto
-    min-width 0
+    float right
+    // 与标签之间的最小间隙（浮动元素不参与标签行的间距）
+    margin-left 8px
 .open-filterbar .open-sort
     // 排序下拉不参与收缩，窄屏下始终完整可点
     flex-shrink 0
@@ -247,10 +259,21 @@
     font-family font-page
     font-size 0.8em
     line-height 1
-    padding 6px 12px
+    // 高度定死（与「+N」按钮、排序下拉等高，见 .open-sort 上方说明）：垂直 padding 归零，
+    // 文案由 align-items center 居中，不靠 padding 撑高（否则字号一变高度就不一致）
+    box-sizing border-box
+    height 30px
+    padding 0 12px
     display inline-flex
     align-items center
     gap 6px
+    // 行内级排列（标签行是块级容器）：与「+N」按钮基线一致；间距由 margin 提供（行内布局没有 gap）
+    vertical-align middle
+    margin-right 8px
+    margin-bottom 8px
+    // 标签文案不换行：chip 内是 flex 容器，文本是匿名 flex item，空间紧张时会被压到
+    // min-content（中文可达单字）而折成多行（如「分库分表」→「分库/分表」）
+    white-space nowrap
     border 1px solid var(--header-divider-color)
     border-radius 999px
     background-color var(--content-bg-color)
@@ -283,6 +306,36 @@
         .open-tagchip-x
             display inline-flex
             opacity 0.85
+
+// 标签折叠按钮「+N」（展开态为「−」）：外观与 .open-tagchip 对齐，虚线边框区分「筛选」与「展开更多」
+.open-tagbar-more
+    font-family font-page
+    font-size 0.8em
+    line-height 1
+    // 高度定死，与 chip / 排序下拉等高（见 .open-sort 上方说明）
+    box-sizing border-box
+    height 30px
+    padding 0 12px
+    display inline-flex
+    align-items center
+    border 1px dashed var(--header-divider-color)
+    border-radius 999px
+    background-color var(--content-bg-color)
+    color var(--text-color)
+    cursor pointer
+    // 不参与收缩，保证「+N」始终完整可点
+    flex-shrink 0
+    // 文案不换行：+N / − 恒为单行
+    white-space nowrap
+    transition all 0.2s
+    user-select none
+    -webkit-tap-highlight-color transparent
+    &:hover
+        border-color color-link
+        color color-link
+    // 必须写在 display:inline-flex 之后：作者样式会盖掉浏览器默认的 [hidden]{display:none}
+    &[hidden]
+        display none
 
 .open-links
     display flex
@@ -640,7 +693,7 @@
         grid-row 1
         grid-column 2
         justify-self end
-    // 手机端排序下拉紧凑化（与标签 chip 同高）
+    // 手机端排序下拉紧凑化：与 chip、「+N」按钮统一 28px（三者必须同高）
     .open-sort
         height 28px
         font-size 0.78em
@@ -660,13 +713,25 @@
             gap 8px
     // 筛选栏行：手机端紧凑化（搜索框 margin-bottom 12px 在 grid 行内，与下方 12px 对齐）
     .open-filterbar
-        gap 6px
         margin 0 0 12px
     .open-tagbar
+        margin-bottom -6px
+    // 控件组同间距紧凑化（与 chip 间距一致）
+    .open-filter-tools
         gap 6px
+        margin-left 6px
     .open-tagchip
         font-size 0.75em
-        padding 5px 10px
+        // 与排序下拉、「+N」按钮同高（28px）；垂直 padding 归零
+        height 28px
+        padding 0 10px
+        margin-right 6px
+        margin-bottom 6px
+    // 折叠按钮与 chip 同尺寸紧凑化
+    .open-tagbar-more
+        font-size 0.75em
+        height 28px
+        padding 0 10px
     // 分页：手机端按钮紧凑化
     .open-pagination
         margin 16px auto 8px

--- a/source/js/open.js
+++ b/source/js/open.js
@@ -139,6 +139,125 @@
                 x.parentNode.removeChild(x);
             }
         });
+        // chip 数量或宽度变化后重算折叠（选中态以 × 替换 count 徽标，宽度与未选中不同）
+        applyTagCollapse();
+    }
+
+    // 筛选栏标签折叠：常用标签过多时，首行放不下的 chip 收进「+N」按钮（点击展开/收起）；
+    // 无 JS 时退化为自然换行（渐进增强）
+    var TAG_GAP_FALLBACK = 8;
+    var tagMoreBtn = null;
+    var tagsExpanded = false;
+    // 控件组（折叠按钮 + 排序下拉）：浮动在标签行右上角，首行标签避让它、其后各行占满整行
+    var filterbar = tagbar ? tagbar.parentNode : null;
+    var tagTools = filterbar ? filterbar.querySelector('.open-filter-tools') : null;
+
+    // chip 间距（PC 8 / 手机 6）：行内级排列下间距由 chip 的 margin 提供，直接从实际样式读取
+    function tagGap() {
+        var c = tagbar.querySelector('.open-tagchip');
+        var m = c ? parseFloat(window.getComputedStyle(c).marginRight) : 0;
+        return m > 0 ? m : TAG_GAP_FALLBACK;
+    }
+
+    function tagbarChips() {
+        return Array.prototype.slice.call(tagbar.querySelectorAll('.open-tagchip'));
+    }
+
+    function ensureMoreBtn() {
+        if (tagMoreBtn) return tagMoreBtn;
+        tagMoreBtn = document.createElement('button');
+        tagMoreBtn.type = 'button';
+        tagMoreBtn.className = 'open-tagbar-more';
+        tagMoreBtn.hidden = true;
+        tagMoreBtn.setAttribute('aria-expanded', 'false');
+        tagMoreBtn.addEventListener('click', function () {
+            tagsExpanded = !tagsExpanded;
+            applyTagCollapse();
+        });
+        return tagMoreBtn;
+    }
+
+    function applyTagCollapse() {
+        if (!tagbar) return;
+        var chips = tagbarChips();
+        var btn = ensureMoreBtn();
+        // 无常用标签：该行只剩排序下拉，按钮不留在 DOM 里
+        if (!chips.length) {
+            if (btn.parentNode) btn.parentNode.removeChild(btn);
+            tagbar.classList.remove('is-collapsed');
+            return;
+        }
+        // 按钮恒居控件组首位（排序下拉之前）
+        if (tagTools) {
+            if (btn.parentNode !== tagTools || tagTools.firstElementChild !== btn) {
+                tagTools.insertBefore(btn, tagTools.firstElementChild);
+            }
+        } else if (btn.parentNode !== tagbar) {
+            tagbar.appendChild(btn);
+        }
+
+        // 测量前复位：chip 全部可见、按钮隐藏
+        chips.forEach(function (c) { c.style.display = ''; });
+        btn.hidden = true;
+
+        // 展开态：全部展示，按钮退化为「−」收起
+        if (tagsExpanded) {
+            tagbar.classList.remove('is-collapsed');
+            btn.hidden = false;
+            btn.textContent = '−';
+            btn.setAttribute('aria-expanded', 'true');
+            btn.setAttribute('aria-label', tagbar.dataset.lessLabel || '收起标签');
+            return;
+        }
+
+        var gap = tagGap();
+
+        // 首行可完整容纳（全部 chip + 控件组）：交回自然排列（不浪费空间），无需折叠
+        var total = 0;
+        chips.forEach(function (c, i) { total += c.offsetWidth + (i ? gap : 0); });
+        if (total + (tagTools ? gap + tagTools.offsetWidth : 0) <= tagbar.clientWidth) {
+            tagbar.classList.remove('is-collapsed');
+            return;
+        }
+
+        // 需要折叠：控件组浮动在标签行右上，首行需让出它的宽度；
+        // 按钮文案（+N 的位数）会改变控件组宽度，故按最终文案再算一趟（首趟占位文案偏宽，会少放一个）
+        var shown = 0;
+        for (var pass = 0; pass < 2; pass++) {
+            chips.forEach(function (c) { c.style.display = ''; });
+            var limit = tagbar.clientWidth - (tagTools ? tagTools.offsetWidth + gap : 0);
+            var acc = 0;
+            shown = 0;
+            for (var i = 0; i < chips.length; i++) {
+                var need = chips[i].offsetWidth + (i ? gap : 0);
+                if (acc + need > limit) break;
+                acc += need;
+                shown++;
+            }
+            if (shown < 1) shown = 1; // 至少保留一个 chip，避免整行只剩按钮
+            btn.hidden = false;
+            btn.textContent = '+' + (chips.length - shown);
+            btn.setAttribute('aria-expanded', 'false');
+            btn.setAttribute('aria-label', tagbar.dataset.moreLabel || '展开全部标签');
+        }
+        tagbar.classList.add('is-collapsed');
+
+        var visible = chips.map(function (_, idx) { return idx < shown; });
+        // 选中态 chip 不能被折叠隐藏（否则 × 清除筛选的入口不可见）：与最后一个可见 chip 互换可见性
+        var activeIdx = -1;
+        chips.forEach(function (c, idx) { if (activeIdx < 0 && c.classList.contains('active')) activeIdx = idx; });
+        if (activeIdx >= shown) {
+            visible[shown - 1] = false;
+            visible[activeIdx] = true;
+        }
+
+        var hiddenN = 0;
+        chips.forEach(function (c, idx) {
+            c.style.display = visible[idx] ? '' : 'none';
+            if (!visible[idx]) hiddenN++;
+        });
+        btn.textContent = '+' + hiddenN;
+        btn.hidden = hiddenN <= 0;
     }
 
     // 排序（⑥）：默认（ejs 的 order 升序）/ 名称升序 / 名称降序；整体重排 DOM 并同步 cards 数组，
@@ -480,8 +599,8 @@
         });
     }
 
-    window.addEventListener('resize', function () { requestAnimationFrame(applyGridCols); requestAnimationFrame(applyClamp); });
-    window.addEventListener('load', function () { requestAnimationFrame(applyClamp); });
+    window.addEventListener('resize', function () { requestAnimationFrame(applyGridCols); requestAnimationFrame(applyClamp); requestAnimationFrame(applyTagCollapse); });
+    window.addEventListener('load', function () { requestAnimationFrame(applyClamp); requestAnimationFrame(applyTagCollapse); });
     // 浏览器前进/后退时按 URL 还原筛选与页码状态
     window.addEventListener('popstate', function () {
         initFromUrl();


### PR DESCRIPTION
- 常用标签超出单行宽度时收进「+N」按钮，点击展开、再点收起；无 JS 时退化为自然换行
- 折叠按钮与排序下拉归入右侧控件组并浮动到标签行右上角，展开成多行时也不会掉行
- 标签行为块级、chip 为行内级：首行避让控件，其后各行占满整行，窄屏不再留大片空白
- 标签 chip / 折叠按钮 / 排序下拉统一高度（PC 30px、手机 28px）
- chip 文案不折行；选中态 chip 折叠时保持可见，保留清除筛选入口
- 新增 i18n 文案 tags_more / tags_less（zh-CN / en）

## PR Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

**Please read and check followings before submitting a PR.**

- [x] The changes have been tested (for bug fixes / features).
- [ ] Others (Update, Documentation, Translation, etc...)

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [x] Improvement.
- [ ] Code style update (e.g. formatting).
- [ ] Refactoring (no changes to functionality and APIs).
- [ ] Documentation.
- [ ] Translation.
- [ ] Version Upgrade.
- [ ] Other... Please describe:
